### PR TITLE
他所から自OrgにForkして置いてるものについての権限設定状況を調べたい

### DIFF
--- a/github-organization-manage.rb
+++ b/github-organization-manage.rb
@@ -92,8 +92,6 @@ module GithubTeamManage
       client = get_client
       client.org_teams(ENV['GITHUB_ORG_NAME']).each do |team|
         client.team_repos(team[:id]).each do |repo|
-          # forkされたリポジトリは除外。検証する意味がないので。
-          next if repo[:fork]
           permission = "Read" if repo[:permissions][:pull]
           permission = "Write" if repo[:permissions][:push]
           permission = "Admin" if repo[:permissions][:admin]


### PR DESCRIPTION
個人で開発してたライブラリを、GitHub OrganizationにForkしてワイワイやる的な状況。Forkしてきたリポジトリに、Organizationで権限管理してる状況を見えるようにしたい。