### PR TITLE
Add Triage and Maintain permission levels to repos_collabs_permission

### DIFF
--- a/github-organization-manage.rb
+++ b/github-organization-manage.rb
@@ -109,9 +109,11 @@ module GithubTeamManage
       client = get_client
       client.org_repos(ENV['GITHUB_ORG_NAME']).each do |repo|
         client.collaborators(repo[:full_name], {"affiliation":"direct"}).each do |collaborator|
-          permission = "Read" if collaborator[:permissions][:pull]
-          permission = "Write" if collaborator[:permissions][:push]
-          permission = "Admin" if collaborator[:permissions][:admin]
+          permission = "Read"     if collaborator[:permissions][:pull]
+          permission = "Triage"   if collaborator[:permissions][:triage]
+          permission = "Write"    if collaborator[:permissions][:push]
+          permission = "Maintain" if collaborator[:permissions][:maintain]
+          permission = "Admin"    if collaborator[:permissions][:admin]
           puts "#{repo[:full_name]},#{collaborator[:login]},#{permission}"
         end
       end


### PR DESCRIPTION
## Summary

- `repos_collabs_permission` の権限判定が3段階 (Read, Write, Admin) のみだったのを、5段階 (Read, Triage, Write, Maintain, Admin) に拡張
- `repos_member_permission` および `repos_team_permission` と同一のパターンに統一

Closes #49

## Test plan

- [ ] `repos_collabs_permission` コマンドを実行し、Triage / Maintain 権限を持つコラボレーターが正しく出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)